### PR TITLE
Mirror + SCD Type II

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,18 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"command": "npm run simple",
+			"name": "simple",
+			"request": "launch",
+			"type": "node-terminal"
+		},
+		{
+			"command": "npm run complex",
+			"name": "complex",
+			"request": "launch",
+			"type": "node-terminal"
+		},			
+		{
 			"type": "node",
 			"request": "launch",
 			"name": "go",
@@ -15,5 +27,6 @@
 			"internalConsoleOptions": "neverOpen",
 			"args": ["--ignore", "./data/"]
 		}
+
 	]
 }

--- a/README.md
+++ b/README.md
@@ -1,50 +1,103 @@
 
-
 # Make Mixpanel Data
-a quick and dirty CLI in node.js to generate fake data for mixpanel.
 
-## tldr;
+## 🤖 What is this?
 
- 
- ```bash
+Generate fake Mixpanel data _quickly_ and _easily_ with a simple CLI in Node.js. **Create events, user profiles, groups profiles, SCD data, mirror tables, and lookup tables**; basically everything you need for testing + demoing mixpanel analysis features. 
+
+the CLI looks like this:
+
+![Generate Mixpanel data](https://aktunes.neocities.org/makeDataDemo.gif)
+
+under the hood, `make-mp-data` is modeling data adherent to match [Mixpanel's data model](https://docs.mixpanel.com/docs/data-structure/concepts), giving you the tools you need for robust, realistical field ready test data.
+
+## 🚀 Quick Start
+
+### Basic Usage
+
+Generate events and users, and write them to CSV files:
+
+```bash
 npx make-mp-data 
 ```
- - makes events + users (and writes them to CSVs)
 
- ```bash
-npx make-mp-data --numUsers 100 --numEvents 10000 --days 90 --format json
+### Customizing Output
+
+Generate 10,000 events and 100 users over the last 90 days, and write the output as JSON:
+
+```bash
+npx make-mp-data --numUsers 100 --numEvents 10000 --numDays 90 --format json
 ```
- - makes ~10k events + 100 users from the last 90 days (but writes JSON)
 
+### Complex Data Models
 
- ```bash
+Create a comprehensive dataset including events, users, groups, SCD, and lookup tables:
+
+```bash
 npx make-mp-data --complex
 ```
- - makes events + users + groups + scd + lookup tables
- - this includes every type of data that mixpanel supports
+
+### Send Data to Mixpanel
+
+Generate and send data directly to Mixpanel using your project token:
 
 ```bash
 npx make-mp-data --token 1234
 ```
- - makes events + users (and send them to mixpanel)
+
+### Help and Options
+
+Need more info on available options?
 
 ```bash
 npx make-mp-data --help
 ```
-- explains all the options you can specify
 
-## customization
+## 🔧 Schema
+
+To choose your own event and property names and values, specify a custom data model and additional options:
 
 ```bash
 npx make-mp-data [dataModel.js] [options]
 ```
-ex.
+
+Example:
 
 ```bash
 npx make-mp-data ecommSpec.js --token 1234 --numDays 30 --numUsers 1000 --numEvents 1000000
 ```
 
-see `--help` for a full list of options
+### Data Models
 
-see `./models/` for a few `dataModel.js` examples...
+Check out `./models/` for example `dataModel.js` files to get started quickly.
 
+## 🛠️ CLI Options
+
+Here's a breakdown of the CLI options you can use with `make-mp-data`:
+
+- `--numUsers`: Number of users to generate.
+- `--numEvents`: Number of events to generate.
+- `--numDays`: Number of days over which to spread the generated data.
+- `--format`: Output format (`csv` or `json`).
+- `--token`: Mixpanel project token for direct data import.
+- `--region`: Mixpanel data region (`US`, `EU`).
+- `--writeToDisk`: Whether to write the data to disk (`true` or `false`).
+- `--verbose`: Enable verbose logging.
+- `--complex`: create a complex set models including groups, SCD, and lookup tables.
+- `--simple`: create a simple dataset including events, and users
+
+## 📄 Examples
+
+Check out the examples directory for sample data models:
+
+```bash
+ls ./models/
+```
+
+These models provide a great starting point for creating your own custom data generation scripts.
+
+## 🤝 Contributing
+
+Feel free to fork this repository and submit pull requests. Contributions are always welcome!
+
+For any issues or feature requests, please create an issue on the [GitHub repository](https://github.com/ak--47/make-mp-data/issues).

--- a/models/complex.js
+++ b/models/complex.js
@@ -128,6 +128,13 @@ const config = {
 		dateOfRenewal: date(100, false),
 	},
 
+	mirrorProps: {
+		actualValue: {
+			events: ["checkout", "sign up"],
+			values: [42, 420, 4, 2, 4200]
+		}
+	},
+
 	/*
 	for group analytics keys, we need an array of arrays [[],[],[]] 
 	each pair represents a group_key and the number of profiles for that key

--- a/models/complex.js
+++ b/models/complex.js
@@ -1,5 +1,5 @@
 /**
- * This is the default configuration file for the data generator
+ * This is the default configuration file for the data generator in COMPLEX mode
  * notice how the config object is structured, and see it's type definition in ./types.d.ts
  * feel free to modify this file to customize the data you generate
  * see helper functions in utils.js for more ways to generate data
@@ -125,14 +125,16 @@ const config = {
 		plan: ["free", "free", "free", "free", "basic", "basic", "basic", "premium", "premium", "enterprise"],
 		MRR: weightedRange(0, 10000, 1000, .15),
 		NPS: weightedRange(0, 10, 150, 2),
-		marketingOptIn: [true, true, false],
-		dateOfRenewal: date(100, false),
+		subscribed: [true, true, true, true, true, true, false, false, false, false, "it's complicated"],
+		renewalDate: date(100, false),
 	},
 
 	mirrorProps: {
-		actualValue: {
-			events: ["checkout", "sign up"],
-			values: [42, 420, 4, 2, 4200]
+		isBot: { events: "*", values: [false, false, false, false, true] },
+		profit: { events: ["checkout"], values: [4, 2, 42, 420] },
+		watchTimeSec: {
+			events: ["watch video"],
+			values: weightedRange(50, 1200, 247, 6)
 		}
 	},
 
@@ -155,9 +157,9 @@ const config = {
 			"products": [["core"], ["core"], ["core", "add-ons"], ["core", "pro-serve"], ["core", "add-ons", "pro-serve"], ["core", "BAA", "enterprise"], ["free"], ["free"], ["free", "addons"]],
 		},
 		room_id: {
-			$name: () => { return `#${chance.word({length: integer(4,24), capitalize: true})}`; },
+			$name: () => { return `#${chance.word({ length: integer(4, 24), capitalize: true })}`; },
 			$email: ["public", "private"],
-			"room provider": ["partner", "core", "core", "core" ],
+			"room provider": ["partner", "core", "core", "core"],
 			"room capacity": weightedRange(3, 1000000),
 			"isPublic": [true, false, false, false, false],
 			"country": chance.country.bind(chance),
@@ -189,7 +191,7 @@ const config = {
 				isFlagged: [true, false, false, false, false],
 				copyright: ["all rights reserved", "creative commons", "creative commons", "public domain", "fair use"],
 				uploader_id: chance.guid.bind(chance),
-				"uploader influence": ["low", "low", "low", "medium", "medium", "high"],				
+				"uploader influence": ["low", "low", "low", "medium", "medium", "high"],
 				rating: weightedRange(1, 5),
 				thumbs: weightedRange(0, 35),
 				rating: ["G", "PG", "PG-13", "R", "NC-17", "PG-13", "R", "NC-17", "R", "PG", "PG"]

--- a/models/complex.js
+++ b/models/complex.js
@@ -59,7 +59,7 @@ const config = {
 				watchTimeSec: weightedRange(10, 600, 1000, .25),
 				quality: ["2160p", "1440p", "1080p", "720p", "480p", "360p", "240p"],
 				format: ["mp4", "avi", "mov", "mpg"],
-				uploader_id: chance.guid.bind(chance)
+				video_id: weightedRange(1, 50000, 420000, 1.4),
 
 			}
 		},
@@ -120,6 +120,7 @@ const config = {
 
 	},
 
+	/** each generates it's own table */
 	scdProps: {
 		plan: ["free", "free", "free", "free", "basic", "basic", "basic", "premium", "premium", "enterprise"],
 		MRR: weightedRange(0, 10000, 1000, .15),
@@ -140,7 +141,8 @@ const config = {
 	each pair represents a group_key and the number of profiles for that key
 	*/
 	groupKeys: [
-		['company_id', 350],
+		['company_id', 500],
+		['room_id', 10000],
 
 	],
 	groupProps: {
@@ -151,6 +153,15 @@ const config = {
 			"industry": ["tech", "finance", "healthcare", "education", "government", "non-profit"],
 			"segment": ["enterprise", "SMB", "mid-market"],
 			"products": [["core"], ["core"], ["core", "add-ons"], ["core", "pro-serve"], ["core", "add-ons", "pro-serve"], ["core", "BAA", "enterprise"], ["free"], ["free"], ["free", "addons"]],
+		},
+		room_id: {
+			$name: () => { return `#${chance.word({length: integer(4,24), capitalize: true})}`; },
+			$email: ["public", "private"],
+			"room provider": ["partner", "core", "core", "core" ],
+			"room capacity": weightedRange(3, 1000000),
+			"isPublic": [true, false, false, false, false],
+			"country": chance.country.bind(chance),
+			"isVerified": [true, true, false, false, false],
 		}
 	},
 
@@ -160,29 +171,7 @@ const config = {
 			entries: 1000,
 			attributes: {
 				category: [
-					"Books",
-					"Movies",
-					"Music",
-					"Games",
-					"Electronics",
-					"Computers",
-					"Smart Home",
-					"Home",
-					"Garden & Tools",
-					"Pet Supplies",
-					"Food & Grocery",
-					"Beauty",
-					"Health",
-					"Toys",
-					"Kids",
-					"Baby",
-					"Handmade",
-					"Sports",
-					"Outdoors",
-					"Automotive",
-					"Industrial",
-					"Entertainment",
-					"Art"
+					"Books", "Movies", "Music", "Games", "Electronics", "Computers", "Smart Home", "Home", "Garden & Tools", "Pet Supplies", "Food & Grocery", "Beauty", "Health", "Toys", "Kids", "Baby", "Handmade", "Sports", "Outdoors", "Automotive", "Industrial", "Entertainment", "Art"
 				],
 				"demand": ["high", "medium", "medium", "low"],
 				"supply": ["high", "medium", "medium", "low"],
@@ -190,6 +179,20 @@ const config = {
 				"price": weightedRange(5, 500, 1000, .25),
 				"rating": weightedRange(1, 5),
 				"reviews": weightedRange(0, 35)
+			}
+
+		},
+		{
+			key: "video_id",
+			entries: 50000,
+			attributes: {
+				isFlagged: [true, false, false, false, false],
+				copyright: ["all rights reserved", "creative commons", "creative commons", "public domain", "fair use"],
+				uploader_id: chance.guid.bind(chance),
+				"uploader influence": ["low", "low", "low", "medium", "medium", "high"],				
+				rating: weightedRange(1, 5),
+				thumbs: weightedRange(0, 35),
+				rating: ["G", "PG", "PG-13", "R", "NC-17", "PG-13", "R", "NC-17", "R", "PG", "PG"]
 			}
 
 		}

--- a/models/deepNest.js
+++ b/models/deepNest.js
@@ -18,17 +18,17 @@ const config = {
 	groupProperties: {}
 };
 
-let formats = ['2160p', '1440p', '1080p', '720p', '480p', '360p', '240p'];
-let ratios = ['4:3', '16:10', '16:9'];
-let containers = ["WEBM", ["MPG", "MP2", "MPEG"], ["MP4", "M4P", "M4V"], ["AVI", "WMV"], ["MOV", "QT"], ["FLV", "SWF"], "AVCHD"];
-let hashtags = ["#AK", "#bitcoin", "#cureForMiley", "#faceValue", "#blm", "#fwiw", "#inappropriateFuneralSongs", "#jurassicPork", "#lolCats", "#wheatForSheep", "#momTexts", "#myWeirdGymStory", "#poppy", "#resist", "#tbt", "#wilson", "#worstGiftEver", "#yolo", "#phish", "#crypto", "#memes", "#wrongMovie", "#careerEndingTwitterTypos", "#twoThingsThatDontMix"];
-let platforms = ["Web", "Mobile Web", "Native (Android)", "Native (iOS)", "Native (Desktop)", "IoT"];
-let plans = ['free', 'premium', 'casual', 'influencer'];
-let categories = ["Product reviews video", "How-to videos", "Vlogs", "Gaming videos", "Comedy/skit videos", "Haul videos", "Memes/tags", "Favorites/best of", "Educational videos", "Unboxing videos", "Q&A videos", "Collection", "Prank videos"];
-let marketingChannels = ["Organic", "Organic", "Organic", "Organic", "Instagram Ads", "Facebook Ads", "Google Ads", "Youtube Ads", "Instagram Post", "Instagram Post", "Facebook Post"];
-
 
 function generateVideoMeta() {
+	let formats = ['2160p', '1440p', '1080p', '720p', '480p', '360p', '240p'];
+	let ratios = ['4:3', '16:10', '16:9'];
+	let containers = ["WEBM", ["MPG", "MP2", "MPEG"], ["MP4", "M4P", "M4V"], ["AVI", "WMV"], ["MOV", "QT"], ["FLV", "SWF"], "AVCHD"];
+	let hashtags = ["#AK", "#bitcoin", "#cureForMiley", "#faceValue", "#blm", "#fwiw", "#inappropriateFuneralSongs", "#jurassicPork", "#lolCats", "#wheatForSheep", "#momTexts", "#myWeirdGymStory", "#poppy", "#resist", "#tbt", "#wilson", "#worstGiftEver", "#yolo", "#phish", "#crypto", "#memes", "#wrongMovie", "#careerEndingTwitterTypos", "#twoThingsThatDontMix"];
+	let platforms = ["Web", "Mobile Web", "Native (Android)", "Native (iOS)", "Native (Desktop)", "IoT"];
+	let plans = ['free', 'premium', 'casual', 'influencer'];
+	let categories = ["Product reviews video", "How-to videos", "Vlogs", "Gaming videos", "Comedy/skit videos", "Haul videos", "Memes/tags", "Favorites/best of", "Educational videos", "Unboxing videos", "Q&A videos", "Collection", "Prank videos"];
+	let marketingChannels = ["Organic", "Organic", "Organic", "Organic", "Instagram Ads", "Facebook Ads", "Google Ads", "Youtube Ads", "Instagram Post", "Instagram Post", "Facebook Post"];
+
 
 	let videoTemplate = {
 		videoFormatInfo: {

--- a/models/simple.js
+++ b/models/simple.js
@@ -24,9 +24,9 @@ const config = {
 
 	events: [
 		{
-			"event": "checkout",
-			"weight": 2,
-			"properties": {
+			event: "checkout",
+			weight: 2,
+			properties: {
 				amount: weightedRange(5, 500, 1000, .25),
 				currency: ["USD", "CAD", "EUR", "BTC", "ETH", "JPY"],
 				coupon: ["none", "none", "none", "none", "10%OFF", "20%OFF", "10%OFF", "20%OFF", "30%OFF", "40%OFF", "50%OFF"],
@@ -35,9 +35,9 @@ const config = {
 			}
 		},
 		{
-			"event": "add to cart",
-			"weight": 4,
-			"properties": {
+			event: "add to cart",
+			weight: 4,
+			properties: {
 				amount: weightedRange(5, 500, 1000, .25),
 				rating: weightedRange(1, 5),
 				reviews: weightedRange(0, 35),
@@ -48,17 +48,17 @@ const config = {
 			}
 		},
 		{
-			"event": "page view",
-			"weight": 10,
-			"properties": {
+			event: "page view",
+			weight: 10,
+			properties: {
 				page: ["/", "/", "/help", "/account", "/watch", "/listen", "/product", "/people", "/peace"],
 				utm_source: ["$organic", "$organic", "$organic", "$organic", "google", "google", "google", "facebook", "facebook", "twitter", "linkedin"],
 			}
 		},
 		{
-			"event": "watch video",
-			"weight": 8,
-			"properties": {
+			event: "watch video",
+			weight: 8,
+			properties: {
 				videoCategory: weighList(videoCategories, integer(0, 9)),
 				isFeaturedItem: [true, false, false],
 				watchTimeSec: weightedRange(10, 600, 1000, .25),
@@ -69,9 +69,9 @@ const config = {
 			}
 		},
 		{
-			"event": "view item",
-			"weight": 8,
-			"properties": {
+			event: "view item",
+			weight: 8,
+			properties: {
 				isFeaturedItem: [true, false, false],
 				itemCategory: weighList(itemCategories, integer(0, 27)),
 				dateItemListed: date(30, true, 'YYYY-MM-DD'),
@@ -79,9 +79,9 @@ const config = {
 			}
 		},
 		{
-			"event": "save item",
-			"weight": 5,
-			"properties": {
+			event: "save item",
+			weight: 5,
+			properties: {
 				isFeaturedItem: [true, false, false],
 				itemCategory: weighList(itemCategories, integer(0, 27)),
 				dateItemListed: date(30, true, 'YYYY-MM-DD'),
@@ -89,10 +89,10 @@ const config = {
 			}
 		},
 		{
-			"event": "sign up",
-			"isFirstEvent": true,
-			"weight": 0,
-			"properties": {
+			event: "sign up",
+			isFirstEvent: true,
+			weight: 0,
+			properties: {
 				variants: ["A", "B", "C", "Control"],
 				flows: ["new", "existing", "loyal", "churned"],
 				flags: ["on", "off"],
@@ -118,6 +118,15 @@ const config = {
 	},
 
 	scdProps: {},
+	mirrorProps: {
+		isBot: { events: "*", values: [false, false, false, false, true] },
+		profit: { events: ["checkout"], values: [4, 2, 42, 420] },
+		watchTimeSec: {
+			events: ["watch video"],
+			values: weightedRange(50, 1200, 247, 6)
+		}
+
+	},
 
 	/*
 	for group analytics keys, we need an array of arrays [[],[],[]] 

--- a/models/simple.js
+++ b/models/simple.js
@@ -1,3 +1,13 @@
+/**
+ * This is the default configuration file for the data generator in SIMPLE mode
+ * notice how the config object is structured, and see it's type definition in ./types.d.ts
+ * feel free to modify this file to customize the data you generate
+ * see helper functions in utils.js for more ways to generate data
+ */
+
+
+
+
 const Chance = require('chance');
 const chance = new Chance();
 const dayjs = require("dayjs");
@@ -117,7 +127,7 @@ const config = {
 		spiritAnimal: ["duck", "dog", "otter", "penguin", "cat", "elephant", "lion", "cheetah", "giraffe", "zebra", "rhino", "hippo", "whale", "dolphin", "shark", "octopus", "squid", "jellyfish", "starfish", "seahorse", "crab", "lobster", "shrimp", "clam", "snail", "slug", "butterfly", "moth", "bee", "wasp", "ant", "beetle", "ladybug", "caterpillar", "centipede", "millipede", "scorpion", "spider", "tarantula", "tick", "mite", "mosquito", "fly", "dragonfly", "damselfly", "grasshopper", "cricket", "locust", "mantis", "cockroach", "termite", "praying mantis", "walking stick", "stick bug", "leaf insect", "lacewing", "aphid", "cicada", "thrips", "psyllid", "scale insect", "whitefly", "mealybug", "planthopper", "leafhopper", "treehopper", "flea", "louse", "bedbug", "flea beetle", "weevil", "longhorn beetle", "leaf beetle", "tiger beetle", "ground beetle", "lady beetle", "firefly", "click beetle", "rove beetle", "scarab beetle", "dung beetle", "stag beetle", "rhinoceros beetle", "hercules beetle", "goliath beetle", "jewel beetle", "tortoise beetle"]
 	},
 
-	scdProps: [],
+	scdProps: {},
 	mirrorProps: {
 		isBot: { events: "*", values: [false, false, false, false, true] },
 		profit: { events: ["checkout"], values: [4, 2, 42, 420] },

--- a/models/simple.js
+++ b/models/simple.js
@@ -117,7 +117,7 @@ const config = {
 		spiritAnimal: ["duck", "dog", "otter", "penguin", "cat", "elephant", "lion", "cheetah", "giraffe", "zebra", "rhino", "hippo", "whale", "dolphin", "shark", "octopus", "squid", "jellyfish", "starfish", "seahorse", "crab", "lobster", "shrimp", "clam", "snail", "slug", "butterfly", "moth", "bee", "wasp", "ant", "beetle", "ladybug", "caterpillar", "centipede", "millipede", "scorpion", "spider", "tarantula", "tick", "mite", "mosquito", "fly", "dragonfly", "damselfly", "grasshopper", "cricket", "locust", "mantis", "cockroach", "termite", "praying mantis", "walking stick", "stick bug", "leaf insect", "lacewing", "aphid", "cicada", "thrips", "psyllid", "scale insect", "whitefly", "mealybug", "planthopper", "leafhopper", "treehopper", "flea", "louse", "bedbug", "flea beetle", "weevil", "longhorn beetle", "leaf beetle", "tiger beetle", "ground beetle", "lady beetle", "firefly", "click beetle", "rove beetle", "scarab beetle", "dung beetle", "stag beetle", "rhinoceros beetle", "hercules beetle", "goliath beetle", "jewel beetle", "tortoise beetle"]
 	},
 
-	scdProps: {},
+	scdProps: [],
 	mirrorProps: {
 		isBot: { events: "*", values: [false, false, false, false, true] },
 		profit: { events: ["checkout"], values: [4, 2, 42, 420] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.25",
       "license": "ISC",
       "dependencies": {
-        "ak-tools": "^1.0.57",
+        "ak-tools": "^1.0.58",
         "chance": "^1.1.11",
         "dayjs": "^1.11.11",
         "mixpanel-import": "^2.5.51",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/ak-tools": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.57.tgz",
-      "integrity": "sha512-7H9XJIl5OpLF7HB7ELs14yilgUQ6Dkl+k+8FdIVZzXP8ki882oyKwE/eXLdQHqJy6fHBl9kohcE281n0cTqYgg=="
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.58.tgz",
+      "integrity": "sha512-58OdUlfKjlpJb7VtfZteFUK543jk+Csxshv3vyN9jI3OhFsZ+Npq7Q0ZKF8GY9OhgdtqLCMbRORc6a4sG5TNMg=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -882,9 +882,9 @@
       }
     },
     "ak-tools": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.57.tgz",
-      "integrity": "sha512-7H9XJIl5OpLF7HB7ELs14yilgUQ6Dkl+k+8FdIVZzXP8ki882oyKwE/eXLdQHqJy6fHBl9kohcE281n0cTqYgg=="
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.58.tgz",
+      "integrity": "sha512-58OdUlfKjlpJb7VtfZteFUK543jk+Csxshv3vyN9jI3OhFsZ+Npq7Q0ZKF8GY9OhgdtqLCMbRORc6a4sG5TNMg=="
     },
     "ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-mp-data",
-  "version": "1.2.25",
+  "version": "1.3.0",
   "description": "builds all mixpanel primitives for a given project",
   "main": "index.js",
   "types": "types.d.ts",
@@ -8,10 +8,10 @@
     "start": "node index.js",
     "dev": "./scripts/go.sh",
     "complex": "nodemon index.js --complex --e 10000 --u 100",
-    "simple": "nodemon index.js  --complex --e 10000 --u 100",
+    "simple": "nodemon index.js  --simple --e 10000 --u 100",
     "prune": "rm ./data/*",
     "post": "npm publish",
-    "test": "jest --runInBand",
+    "test": "NODE_ENV=test jest --runInBand",
     "deps": "sh ./scripts/deps.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "node index.js",
     "dev": "./scripts/go.sh",
-	"complex": "nodemon index.js --complex",
-	"simple": "nodemon index.js",
+    "complex": "nodemon index.js --complex --e 10000 --u 100",
+    "simple": "nodemon index.js  --complex --e 10000 --u 100",
     "prune": "rm ./data/*",
     "post": "npm publish",
     "test": "jest --runInBand",
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/ak--47/make-mp-data#readme",
   "dependencies": {
-    "ak-tools": "^1.0.57",
+    "ak-tools": "^1.0.58",
     "chance": "^1.1.11",
     "dayjs": "^1.11.11",
     "mixpanel-import": "^2.5.51",

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -24,7 +24,7 @@ describe('module', () => {
 		expect(eventData.length).toBeGreaterThan(980);
 		expect(groupProfilesData.length).toBe(0);
 		expect(lookupTableData.length).toBe(0);
-		expect(scdTableData.length).toBeGreaterThan(200);
+		expect(scdTableData.length).toBe(0);
 		expect(userProfilesData.length).toBe(100);		
 
 	}, timeout);
@@ -61,7 +61,7 @@ describe('module', () => {
 		expect(eventData.length).toBeGreaterThan(980);
 		expect(groupProfilesData.length).toBe(0);
 		expect(lookupTableData.length).toBe(0);
-		expect(scdTableData.length).toBeGreaterThan(200);
+		expect(scdTableData.length).toBe(0);
 		expect(userProfilesData.length).toBe(100);
 
 	}, timeout);
@@ -75,7 +75,7 @@ describe('cli', () => {
 		const run = execSync(`node ./index.js --numEvents 1000 --numUsers 100 --seed "deal with it" --complex`);
 		expect(run.toString().trim().includes('have a wonderful day :)')).toBe(true);
 		const csvs = (await u.ls('./data')).filter(a => a.includes('.csv'));
-		expect(csvs.length).toBe(5);
+		expect(csvs.length).toBe(6);
 		clearData();
 	}, timeout);
 
@@ -84,7 +84,7 @@ describe('cli', () => {
 		const run = execSync(`node ./index.js --numEvents 1000 --numUsers 100 --seed "deal with it"`);
 		expect(run.toString().trim().includes('have a wonderful day :)')).toBe(true);
 		const csvs = (await u.ls('./data')).filter(a => a.includes('.csv'));
-		expect(csvs.length).toBe(2);
+		expect(csvs.length).toBe(3);
 		clearData();
 	}, timeout);
 
@@ -93,7 +93,7 @@ describe('cli', () => {
 		const run = execSync(`node ./index.js ./models/deepNest.js`);
 		expect(run.toString().trim().includes('have a wonderful day :)')).toBe(true);
 		const csvs = (await u.ls('./data')).filter(a => a.includes('.csv'));
-		expect(csvs.length).toBe(3);
+		expect(csvs.length).toBe(2);
 		clearData();
 	}, timeout);
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -46,10 +46,10 @@ describe('module', () => {
 		const results = await generate({ ...complex, verbose: true, writeToDisk: false, numEvents: 1100, numUsers: 100, seed: "deal with it" });
 		const { eventData, groupProfilesData, lookupTableData, scdTableData, userProfilesData } = results;
 		expect(eventData.length).toBeGreaterThan(980);
-		expect(groupProfilesData[0]?.data?.length).toBe(350);
-		expect(lookupTableData.length).toBe(1);
+		expect(groupProfilesData[0]?.data?.length).toBe(500);
+		expect(lookupTableData.length).toBe(2);
 		expect(lookupTableData[0].data.length).toBe(1000);
-		expect(scdTableData.length).toBeGreaterThan(200);
+		expect(scdTableData.length).toBe(5);
 		expect(userProfilesData.length).toBe(100);
 
 	}, timeout);
@@ -66,16 +66,25 @@ describe('module', () => {
 
 	}, timeout);
 
+	test('fails with invalid configuration', async () => {
+		try {
+		  await generate({ numUsers: -10 });
+		} catch (e) {
+		  expect(e).toBeDefined();
+		}
+	  }, timeout);
+	  
+
 
 });
 
 describe('cli', () => {
 	test('works as CLI (complex)', async () => {
 		console.log('COMPLEX CLI TEST');
-		const run = execSync(`node ./index.js --numEvents 1000 --numUsers 100 --seed "deal with it" --complex`);
-		expect(run.toString().trim().includes('have a wonderful day :)')).toBe(true);
+		const run = execSync(`node ./index.js --numEvents 1000 --numUsers 100 --seed "deal with it" --complex`, { stdio: 'ignore' });
+		// expect(run.toString().trim().includes('have a wonderful day :)')).toBe(true);
 		const csvs = (await u.ls('./data')).filter(a => a.includes('.csv'));
-		expect(csvs.length).toBe(6);
+		expect(csvs.length).toBe(12);
 		clearData();
 	}, timeout);
 
@@ -98,6 +107,7 @@ describe('cli', () => {
 	}, timeout);
 
 });
+
 
 describe('options + tweaks', () => {
 	test('creates sessionIds', async () => {

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -60,7 +60,7 @@ describe('utils', () => {
 		const generatedPerson = person();
 		expect(generatedPerson).toHaveProperty('$name');
 		expect(generatedPerson).toHaveProperty('$email');
-		expect(generatedPerson).toHaveProperty('$avatar');		
+		expect(generatedPerson).toHaveProperty('$avatar');
 	});
 
 
@@ -95,6 +95,38 @@ describe('utils', () => {
 		const result = choose(() => 'test');
 		expect(result).toBe('test');
 	});
+
+	test('choose: non-function / non-array', () => {
+		expect(choose('test')).toBe('test');
+		expect(choose(123)).toBe(123);
+	});
+
+	test('choose: nested functions', () => {
+		const result = choose(() => () => () => 'nested');
+		expect(result).toBe('nested');
+	});
+
+	test('weightedRange:  within range', () => {
+		const values = weightedRange(5, 15, 100);
+		expect(values.every(v => v >= 5 && v <= 15)).toBe(true);
+		expect(values.length).toBe(100);
+	});
+
+	test('applySkew: skews', () => {
+		const value = boxMullerRandom();
+		const skewedValue = applySkew(value, .25);
+		expect(Math.abs(skewedValue)).toBeGreaterThanOrEqual(Math.abs(value));
+	});
+
+	test('mapToRange: works', () => {
+		const value = 0;
+		const mean = 10;
+		const sd = 5;
+		const mappedValue = mapToRange(value, mean, sd);
+		expect(mappedValue).toBe(10);
+	  });
+	  
+
 
 	test('exhaust: elements', () => {
 		const arr = [1, 2, 3];
@@ -161,7 +193,7 @@ describe('utils', () => {
 		expect(typeof emojis).toBe('string');
 		const emojiArray = emojis.split(', ');
 		expect(emojiArray.length).toBeLessThanOrEqual(10); // Assuming max default is 10
-		
+
 	});
 
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,7 +16,7 @@ declare namespace main {
     events?: EventConfig[];
     superProps?: Record<string, valueValid>;
     userProps?: Record<string, valueValid>;
-    scdProps?: Record<string, valueValid>;
+    scdProps?: SCDTable[];
 	mirrorProps?: Record<string, { events: string[]; values: valueValid[] }>;
     groupKeys?: [string, number][];
     groupProps?: Record<string, GroupProperty>; // Adjust according to usage
@@ -50,6 +50,17 @@ declare namespace main {
     attributes: {
       [key?: string]: valueValid;
     };
+  }
+
+  interface SCDTable {
+	distinct_id: string;
+	insertTime: string;
+	startTime: string;
+	[key: string]: valueValid;
+  }
+
+  interface SCDProps {
+	[key: string]: valueValid;
   }
 
   type Result = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,6 +17,7 @@ declare namespace main {
     superProps?: Record<string, valueValid>;
     userProps?: Record<string, valueValid>;
     scdProps?: Record<string, valueValid>;
+	mirrorProps?: Record<string, { events: string[]; values: valueValid[] }>;
     groupKeys?: [string, number][];
     groupProps?: Record<string, GroupProperty>; // Adjust according to usage
     lookupTables?: LookupTable[];

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,94 +1,114 @@
 declare namespace main {
-  type primitives = string | number | boolean | Date | Object;
-  type valueValid =
-    | primitives
-    | primitives[]
-    | (() => primitives | primitives[]);
-
-  export interface Config {
-    token?: string;
-    seed?: string;
-    numDays?: number;
-    numEvents?: number;
-    numUsers?: number;
-    format?: "csv" | "json";
-    region?: string;
-    events?: EventConfig[];
-    superProps?: Record<string, valueValid>;
-    userProps?: Record<string, valueValid>;
-    scdProps?: SCDTable[];
-	mirrorProps?: Record<string, { events: string[]; values: valueValid[] }>;
-    groupKeys?: [string, number][];
-    groupProps?: Record<string, GroupProperty>; // Adjust according to usage
-    lookupTables?: LookupTable[];
-    writeToDisk?: boolean;
-    simulationName?: string;
-    verbose?: boolean;
-    anonIds?: boolean;
-    sessionIds?: boolean;
-    hook?: Hook;
+	type Primitives = string | number | boolean | Date | Record<string, any>;
+  
+	// Recursive type to handle functions returning functions that eventually return Primitives or arrays of Primitives
+	type ValueValid =
+	  | Primitives
+	  | ValueValid[]
+	  | (() => ValueValid);
+  
+	// MAIN CONFIGURATION OBJECT
+	export interface Config {
+	  token?: string;
+	  seed?: string;
+	  numDays?: number;
+	  numEvents?: number;
+	  numUsers?: number;
+	  format?: "csv" | "json";
+	  region?: string;
+	  events?: EventConfig[];
+	  superProps?: Record<string, ValueValid>;
+	  userProps?: Record<string, ValueValid>;
+	  scdProps?: Record<string, ValueValid>;
+	  mirrorProps?: Record<string, MirrorProps>;
+	  groupKeys?: [string, number][];
+	  groupProps?: Record<string, Record<string, ValueValid>>;
+	  lookupTables?: LookupTable[];
+	  writeToDisk?: boolean;
+	  simulationName?: string;
+	  verbose?: boolean;
+	  anonIds?: boolean;
+	  sessionIds?: boolean;
+	  hook?: Hook;
+	}
+  
+	export type Hook = (record: any, type: string, meta: any) => any;
+  
+	export interface EventConfig {
+	  event?: string;
+	  weight?: number;
+	  properties?: Record<string, ValueValid>;
+	  isFirstEvent?: boolean;
+	}
+  
+	export interface MirrorProps {
+	  events: string[] | "*";
+	  values: ValueValid[];
+	}
+  
+	export interface LookupTable {
+	  key: string;
+	  entries: number;
+	  attributes: Record<string, ValueValid>;
+	}
+  
+	export interface SCDTable {
+	  distinct_id: string;
+	  insertTime: string;
+	  startTime: string;
+	  [key: string]: ValueValid;
+	}
+  
+	export type Result = {
+	  eventData: EventData[];
+	  userProfilesData: any[];
+	  scdTableData: any[];
+	  groupProfilesData: GroupProfilesData[];
+	  lookupTableData: LookupTableData[];
+	  import?: ImportResults;
+	  files?: string[];
+	};
+  
+	export interface EventData {
+	  event: string;
+	  $source: string;
+	  time: string;
+	  $device_id?: string;
+	  $session_id?: string;
+	  $user_id?: string;
+	  [key: string]: any;
+	}
+  
+	export interface GroupProfilesData {
+	  key: string;
+	  data: any[];
+	}
+  
+	export interface LookupTableData {
+	  key: string;
+	  data: any[];
+	}
+  
+	export interface ImportResults {
+	  events: ImportResult;
+	  users: ImportResult;
+	  groups: ImportResult[];
+	}
+  
+	export interface ImportResult {
+	  success: number;
+	  bytes: number;
+	}
   }
-
-  export type Hook = (record: any, type: string, meta: any) => any;
-
-  interface EventConfig {
-    event?: string;
-    weight?: number;
-    properties?: {
-      [key: string]: valueValid; // Consider refining based on actual properties used
-    };
-    isFirstEvent?: boolean;
-  }
-
-  interface GroupProperty {
-    [key?: string]: valueValid;
-  }
-
-  interface LookupTable {
-    key: string;
-    entries: number;
-    attributes: {
-      [key?: string]: valueValid;
-    };
-  }
-
-  interface SCDTable {
-	distinct_id: string;
-	insertTime: string;
-	startTime: string;
-	[key: string]: valueValid;
-  }
-
-  interface SCDProps {
-	[key: string]: valueValid;
-  }
-
-  type Result = {
-    eventData: {
-      event: any;
-      $source: string;
-    }[];
-    userProfilesData: any[];
-    scdTableData: any[];
-    groupProfilesData: {
-      key: string;
-      data: any[];
-    }[];
-    lookupTableData: {
-      key: string;
-      data: any[];
-    }[];
-    import?: undefined;
-    files?: undefined;
-  };
-}
-
-/**
- * Mixpanel Data Generator
- * model events, users, groups, and lookup tables (and SCD props!)
- * @example
- * const gen = require('make-mp-data')
- * const dta = gen({writeToDisk: false})
- */
-declare function main(config: main.Config): Promise<main.Result>;
-export = main;
+  
+  /**
+   * Mixpanel Data Generator
+   * model events, users, groups, and lookup tables (and SCD props!)
+   * @example
+   * const gen = require('make-mp-data')
+   * const dta = gen({writeToDisk: false})
+   */
+  declare function main(config: main.Config): Promise<main.Result>;
+  
+  export = main;
+  

--- a/utils.js
+++ b/utils.js
@@ -155,7 +155,7 @@ function mapToRange(value, mean, sd) {
 	return Math.round(value * sd + mean);
 };
 
-function weightedRange(min, max, size = 100, skew = 1) {
+function unOptimizedWeightedRange(min, max, size = 100, skew = 1) {
 	const mean = (max + min) / 2;
 	const sd = (max - min) / 4;
 	let array = [];
@@ -175,6 +175,23 @@ function weightedRange(min, max, size = 100, skew = 1) {
 
 	return array;
 };
+
+// optimized weighted range
+function weightedRange(min, max, size = 100, skew = 1) {
+    const mean = (max + min) / 2;
+    const sd = (max - min) / 4;
+    const array = [];
+    while (array.length < size) {
+        const normalValue = boxMullerRandom();
+        const skewedValue = applySkew(normalValue, skew);
+        const mappedValue = mapToRange(skewedValue, mean, sd);
+        if (mappedValue >= min && mappedValue <= max) {
+            array.push(mappedValue);
+        }
+    }
+    return array;
+}
+
 
 function progress(thing, p) {
 	readline.cursorTo(process.stdout, 0);


### PR DESCRIPTION
`make-map-data` now:

- puts SCD properties in separate tables
- describes late-arriving data in mirror tables using `mirrorProps`
- has `hooks` so each chosen event / prop can be tweaked at simulation time
- has some code cleanup
- has telemetry so we can track usage
- has tests so i don't lose sleep


roadmap: selective group props for b2b