### PR TITLE
Include writeToDisk in Mixpanel import checks

### DIFF
--- a/lib/orchestrators/mixpanel-sender.js
+++ b/lib/orchestrators/mixpanel-sender.js
@@ -65,7 +65,7 @@ export async function sendToMixpanel(context) {
 	log(`${'─'.repeat(50)}\n`);
 
 	// Import events
-	if (eventData?.length > 0 || isBATCH_MODE) {
+	if (eventData?.length > 0 || isBATCH_MODE || writeToDisk) {
 		log(`  Events`);
 		let eventDataToImport = u.deepClone(eventData);
 		const shouldReadFromFiles = isBATCH_MODE || (writeToDisk && eventData && eventData.length === 0);
@@ -84,7 +84,7 @@ export async function sendToMixpanel(context) {
 	}
 
 	// Import user profiles
-	if (userProfilesData?.length > 0 || isBATCH_MODE) {
+	if (userProfilesData?.length > 0 || isBATCH_MODE || writeToDisk) {
 		log(`  User Profiles`);
 		let userProfilesToImport = u.deepClone(userProfilesData);
 		const shouldReadFromFiles = isBATCH_MODE || (writeToDisk && userProfilesData && userProfilesData.length === 0);
@@ -103,7 +103,7 @@ export async function sendToMixpanel(context) {
 	}
 
 	// Import ad spend data
-	if (adSpendData?.length > 0 || isBATCH_MODE) {
+	if (adSpendData?.length > 0 || isBATCH_MODE || (writeToDisk && config.hasAdSpend)) {
 		log(`  Ad Spend`);
 		let adSpendDataToImport = u.deepClone(adSpendData);
 		const shouldReadFromFiles = isBATCH_MODE || (writeToDisk && adSpendData && adSpendData.length === 0);


### PR DESCRIPTION
Context: I was running make-mp-data --numUsers 10000 --numEvents 1 --numDays 90 --token proj_token

and it was not actually flushing to Mixpanel

Claude fixed it here: 

Allow Mixpanel import orchestrator to run when writeToDisk mode is enabled. Updated the conditionals for Events and User Profiles to also trigger when writeToDisk is true, and updated the Ad Spend check to require writeToDisk and config.hasAdSpend. This ensures the code will read from disk or perform import logic even when in write-to-disk mode and the in-memory arrays are empty.